### PR TITLE
Added expected assertions to asynchronous tests.

### DIFF
--- a/harperdb-connect.test.js
+++ b/harperdb-connect.test.js
@@ -38,6 +38,7 @@ describe('HarperDBConnect Class', () => {
 
   test('can be instantiated with username, password, and url', async () => {
     expect.assertions(3)
+    db = await new HarperDBConnect('username', 'password', 'http://mockdb.url/')
     expect(db).toBeDefined()
     expect(db).toBeInstanceOf(HarperDBConnect)
     expect(db.options.url).toBeDefined()

--- a/harperdb-connect.test.js
+++ b/harperdb-connect.test.js
@@ -37,6 +37,7 @@ describe('HarperDBConnect Class', () => {
   })
 
   test('can be instantiated with username, password, and url', async () => {
+    expect.assertions(3)
     expect(db).toBeDefined()
     expect(db).toBeInstanceOf(HarperDBConnect)
     expect(db.options.url).toBeDefined()
@@ -121,6 +122,7 @@ describe('HarperDBConnect Class', () => {
 
   describe('Method Parameters', () => {
     test('setOperation() throws error for invalid parameters', () => {
+      expect.assertions(4)
       db = new HarperDBConnect()
       expect(_ => db.setAuthorization(0, 0)).toThrowError(TypeError)
       expect(_ => db.setAuthorization(0, 0)).toThrowError(
@@ -133,6 +135,7 @@ describe('HarperDBConnect Class', () => {
     })
 
     test('setDefaultOptions() throws error for invalid parameters', () => {
+      expect.assertions(2)
       expect(_ => db.setDefaultOptions('notObject')).toThrowError(TypeError)
       expect(_ => db.setDefaultOptions('notObject')).toThrowError(
         'options must be defined and of type object'
@@ -140,6 +143,7 @@ describe('HarperDBConnect Class', () => {
     })
 
     test('connect() throws error for invalid parameters', () => {
+      expect.assertions(4)
       db = new HarperDBConnect()
       expect(_ => db.connect(0)).toThrowError(TypeError)
       expect(_ => db.connect(0)).toThrowError(
@@ -152,6 +156,7 @@ describe('HarperDBConnect Class', () => {
     })
 
     test('request() throws error for invalid parameters', () => {
+      expect.assertions(4)
       expect(_ => db.request('notObject')).toThrowError(TypeError)
       expect(_ => db.request('notObject')).toThrowError(
         'queryOrOptions must be defined and of type object'

--- a/harperdb-connect.test.js
+++ b/harperdb-connect.test.js
@@ -29,6 +29,7 @@ describe('HarperDBConnect Class', () => {
   })
 
   test('can be instantiated with only username and password', () => {
+    expect.assertions(3)
     db = new HarperDBConnect('username', 'password')
     expect(db).toBeDefined()
     expect(db).toBeInstanceOf(HarperDBConnect)
@@ -42,6 +43,7 @@ describe('HarperDBConnect Class', () => {
   })
 
   test('instantiation rejects bad connection', async () => {
+    expect.assertions(1)
     try {
       db = await new HarperDBConnect('username', 'password', 'http://bad.url')
     } catch (e) {
@@ -50,12 +52,14 @@ describe('HarperDBConnect Class', () => {
   })
 
   test('resolves connection with valid options.url', async () => {
+    expect.assertions(1)
     db = new HarperDBConnect('username', 'password')
     db.setDefaultOptions({ url: 'http://mockdb.url' })
     await expect(db.connect()).resolves.toBe('http://mockdb.url')
   })
 
   test('rejects connection with bad url', async () => {
+    expect.assertions(1)
     db = new HarperDBConnect('username', 'password')
     try {
       await db.connect('http://bad.url')
@@ -65,6 +69,7 @@ describe('HarperDBConnect Class', () => {
   })
 
   test('resolves request without useDefault', async () => {
+    expect.assertions(1)
     await expect(
       db.request(
         {
@@ -83,6 +88,7 @@ describe('HarperDBConnect Class', () => {
   })
 
   test('resolves request with useDefault', async () => {
+    expect.assertions(1)
     db.setDefaultOptions({
       method: 'POST',
       headers: {
@@ -103,6 +109,7 @@ describe('HarperDBConnect Class', () => {
   })
 
   test('rejects request when not connected', async () => {
+    expect.assertions(1)
     db = new HarperDBConnect('username', 'password')
 
     await expect(db.request({})).rejects.toEqual(

--- a/harperdb-connect.test.js
+++ b/harperdb-connect.test.js
@@ -40,8 +40,10 @@ describe('HarperDBConnect Class', () => {
     expect.assertions(3)
     db = await new HarperDBConnect('username', 'password', 'http://mockdb.url/')
     expect(db).toBeDefined()
-    expect(db).toBeInstanceOf(HarperDBConnect)
     expect(db.options.url).toBeDefined()
+    await expect(
+      new HarperDBConnect('username', 'password', 'http://mockdb.url/')
+    ).resolves.toBeInstanceOf(HarperDBConnect)
   })
 
   test('instantiation rejects bad connection', async () => {


### PR DESCRIPTION
I found out that there is test marked as async but without any await keyword specified inside function body. Shouldn't the async keyword be removed is such case ?